### PR TITLE
Override Container Logging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 *
-
+!docker-image-files/**/*
 !target/coach*jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,21 @@ FROM eclipse-temurin:11
 # Continue with your application deployment
 RUN groupadd coach -g 9999 && \
     useradd coach -d / -g 9999 -u 9999 -M -s /sbin/nologin
-RUN mkdir /opt/app && chown coach:coach /opt/app
-COPY target/coach.jar /opt/app/coach.jar
+
+RUN mkdir /opt/app && \
+    mkdir /opt/app/defaults && \
+    mkdir /opt/app/config && \
+    mkdir /opt/app/logs && \
+    chown -R coach:coach /opt/app
+COPY --chown=coach:coach docker-image-files/logback.xml /opt/app/defaults/logback.xml
+COPY --chown=coach:coach docker-image-files/logback.xml /opt/app/config/logback.xml
+COPY --chown=coach:coach target/coach.jar /opt/app/coach.jar
+
+COPY docker-image-files/entrypoint.sh /entrypoint.sh
+RUN chmod 755 /entrypoint.sh
+
 USER coach
 WORKDIR /opt/app
 EXPOSE 8082
-CMD ["java", "-jar", "/opt/app/coach.jar"]
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["java", "-Dlogging.config=/opt/app/config/logback.xml", "-jar", "/opt/app/coach.jar"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,6 +7,8 @@ services:
     depends_on:
       - mysql
       - cqfruler
+    volumes:
+      - ./docker_data/logs:/opt/app/logs
     environment:
       - SPRING_DATASOURCE_URL=jdbc:mysql://mysql/coach
       - CQFRULER_CDSHOOKS_ENDPOINT_URL=http://cqfruler:8080/cds-services

--- a/docker-image-files/entrypoint.sh
+++ b/docker-image-files/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+APP_PATH="/opt/app"
+CONFIG_DIR="$APP_PATH/config"
+DEFAULTS_DIR="$APP_PATH/defaults"
+LOGBACK_CONFIG="logback.xml"
+
+# copy logging configuration if the directory is overridden but logback.xml is missing
+if ! [ -f "$CONFIG_DIR/$LOGBACK_CONFIG" ]; then
+    cp $DEFAULTS_DIR/$LOGBACK_CONFIG $CONFIG_DIR/$LOGBACK_CONFIG
+fi
+
+exec $@

--- a/docker-image-files/logback.xml
+++ b/docker-image-files/logback.xml
@@ -1,0 +1,35 @@
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%file:%line] %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/opt/app/logs/coach.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>coach.%d{yyyy-MM-dd}.log.zip</fileNamePattern>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%file:%line] %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE" />
+    </root>
+
+    <logger name="edu.ohsu.cmp.coach.workspace.UserWorkspace" level="DEBUG" />
+    <logger name="edu.ohsu.cmp.coach.service.RecommendationService" level="INFO" />
+    <logger name="edu.ohsu.cmp.coach.service.EHRService" level="DEBUG" />
+    <logger name="edu.ohsu.cmp.coach.service.FHIRService" level="INFO" />
+    <logger name="edu.ohsu.cmp.coach.fhir.EncounterMatcher" level="DEBUG" />
+    <logger name="edu.ohsu.cmp.coach.controller.MedicationController" level="DEBUG" />
+    <logger name="edu.ohsu.cmp.coach.service.MedicationService" level="DEBUG" />
+
+</configuration>


### PR DESCRIPTION
Add an entrypoint script and Logback configuration to allow capturing log files in a volume.

## Discussion

I initially thought the application's `logback.xml` wasn't necessary, because Spring Boot provides equivalent configuration through `application.properties`. Unfortunately, one of the dependency jars provides a `logback.xml`, and despite multiple efforts with different Maven plugins, I was unable to exclude it.

Overriding the Logback configuration is simple enough, but an entrypoint script is needed to ensure that the image doesn't crash at startup if the user mounts a file system directory to `/opt/app/config`.