### PR TITLE
Automatically Create Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Using the docker-compose file provided, you can run the MySQL database as a cont
 
 ```docker-compose up mysql```
 
-Once it is up, connect to it on localhost:3306 and create the schema using the file [db-schema.sql](db-schema.sql). You only have to create the schema the first time you run the container. It will persist on restart.
+The schema will be created using the file [db-schema.sql](db-schema.sql) the first time the conainer runs. It will persist on restart.
 
 ## Running CQF Ruler as a container
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Using the docker-compose file provided, you can run the MySQL database as a cont
 
 ```docker-compose up mysql```
 
-The schema will be created using the file [db-schema.sql](db-schema.sql) the first time the conainer runs. It will persist on restart.
+The schema will be created using the file [db-schema.sql](db-schema.sql) the first time the container runs. It will persist on restart.
 
 ## Running CQF Ruler as a container
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -12,7 +12,7 @@ services:
       - CQFRULER_CDSHOOKS_ENDPOINT_URL=http://cqfruler:8080/cds-services
       - VSAC_API_KEY
   mysql:
-    image: mysql:5.7
+    image: mysql:8
     volumes:
       - ./docker_data/mysql:/var/lib/mysql
       - ./db-schema.sql:/docker-entrypoint-initdb.d/db-schema.sql

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -15,6 +15,7 @@ services:
     image: mysql:5.7
     volumes:
       - ./docker_data/mysql:/var/lib/mysql
+      - ./db-schema.sql:/docker-entrypoint-initdb.d/db-schema.sql
     ports:
       - "3306:3306"
     environment:


### PR DESCRIPTION
Automatically run DDL script to create the COACH schema the first time that the MySQL container starts.