### PR TITLE
Document How to Override Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In order to run COACH, connections to the database, the EHR FHIR server, and CQF
 
 If you already have these pieces in place and they are externally addressable, then configure a properties file to provide COACH the information needed. Make a local copy of [application.properties](src/main/resources/application.properties), override any configuration needed, and mount the file into the Docker container when running:
 
-```docker run -p 8082:8082 -v $(pwd)/override.properties:/opt/app/application.properties ghcr.io/ohsucmp/coach```
+```docker run -p 8082:8082 -v $(pwd)/override.properties:/opt/app/config/application.properties ghcr.io/ohsucmp/coach```
 
 If you want to run everything locally, both the database and CQF Ruler can also be set up as containers. Docker-compose files are provided to facilitate this. To use these, clone this repository. Copy the file "env.sample" to ".env" and fill out the API key in this file.
 
@@ -42,5 +42,10 @@ The docker-compose setup creates connections between the three Dockerized contai
 
 ```docker-compose up app```
 
+### Configuration
 
+As described above, you can override the application's configuration by making a copy of [application.properties](./src/main/resources/application.properties), overriding the desired properties, and mounting the file into the container at `/opt/app/config/application.properties`. An example mount definition is included in [docker-compose.override.yml](./docker-compose.override.yml).
 
+### Logging
+
+In addition to being sent to the console, logs from the COACH container are persisted to `./docker_data/coach/logs`. If this isn't desirable, you can override the logging configuration by mounting a `logback.xml` file into the container at `/opt/app/config/logback.xml`. You can find example configuration in [logback-console-only.xml](./docker-image-files/logback-console-only.xml) and comments in [docker-compose.override.yml](./docker-compose.override.yml).

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,7 +8,11 @@ services:
       - mysql
       - cqfruler
     volumes:
-      - ./docker_data/logs:/opt/app/logs
+      - ./docker_data/coach/logs:/opt/app/logs
+      # to override logging configuration, mount a logback.xml file to /opt/app/config
+      # - ./docker_data/coach/logback.xml:/opt/app/config/logback.xml
+      # to override configuration properties, mount an application.properties file to /opt/app/config
+      # - ./docker_data/coach/application.properties:/opt/app/config/application.properties
     environment:
       - SPRING_DATASOURCE_URL=jdbc:mysql://mysql/coach
       - CQFRULER_CDSHOOKS_ENDPOINT_URL=http://cqfruler:8080/cds-services

--- a/docker-image-files/logback-console-only.xml
+++ b/docker-image-files/logback-console-only.xml
@@ -1,0 +1,21 @@
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%file:%line] %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="edu.ohsu.cmp.coach.workspace.UserWorkspace" level="DEBUG" />
+    <logger name="edu.ohsu.cmp.coach.service.RecommendationService" level="INFO" />
+    <logger name="edu.ohsu.cmp.coach.service.EHRService" level="DEBUG" />
+    <logger name="edu.ohsu.cmp.coach.service.FHIRService" level="INFO" />
+    <logger name="edu.ohsu.cmp.coach.fhir.EncounterMatcher" level="DEBUG" />
+    <logger name="edu.ohsu.cmp.coach.controller.MedicationController" level="DEBUG" />
+    <logger name="edu.ohsu.cmp.coach.service.MedicationService" level="DEBUG" />
+
+</configuration>


### PR DESCRIPTION
Document how to override the application's configuration.

## Discussion

This PR updates README.md with information on how to override logging and application configuration. For consistency and to facilitate overriding multiple configuration files, I updated the suggested location of `application.properties` to `/opt/app/config`. Conveniently, this is one of the [default locations Spring Boot searches for properties files](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#features.external-config.files).

I verified that I could override the values of `FhirConfigManager.java` and `FhirQueryManager.java` by mounting versions of the corresponding properties files and overriding `application.properties` as follows:

```properties
fhirqueries.file=file:/opt/app/config/fhirqueries.properties
fhirconfig.file=file:/opt/app/config/fhirconfig.properties
```

So this implementation meets that requirement as expected.