### PR TITLE
LOESS improvements

### DIFF
--- a/src/main/java/edu/ohsu/cmp/coach/controller/HomeController.java
+++ b/src/main/java/edu/ohsu/cmp/coach/controller/HomeController.java
@@ -47,9 +47,6 @@ public class HomeController extends BaseController {
     @Autowired
     private MedicationService medicationService;
 
-    @Value("${graph.trendline.loess-bandwidth}")
-    private Number loessBandwidth;
-
     @GetMapping(value = {"", "/"})
     public String view(HttpSession session, Model model,
                        @RequestParam(name = "bandwidth", required = false) Number bandwidthOverride) {
@@ -58,8 +55,7 @@ public class HomeController extends BaseController {
         model.addAttribute("applicationName", applicationName);
         model.addAttribute("sessionEstablished", String.valueOf(sessionEstablished));
 
-        Number b = bandwidthOverride != null ? bandwidthOverride : loessBandwidth;
-        model.addAttribute("loessBandwidth", b);
+        model.addAttribute("loessBandwidth", bandwidthOverride == null ? -1:bandwidthOverride);
 
         if (sessionEstablished) {
             logger.info("requesting data for session " + session.getId());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,8 +10,6 @@ security.browser.cache-credentials=false
 
 feature.button.clear-supplemental-data.show=false
 
-graph.trendline.loess-bandwidth=0.2
-
 socket.timeout=3600000
 
 spring.mvc.async.request-timeout=3600000

--- a/src/main/resources/static/js/home.js
+++ b/src/main/resources/static/js/home.js
@@ -145,8 +145,10 @@ function getBPSetStartDate(bps) {
 function calculateAverageBP(bps) {
     const bpset = getBPSet(bps);
     if (bpset) {
-        const avgSys = bpset.reduce((acc,bp) => acc + bp.systolic.value, 0)/bpset.length;
-        const avgDia = bpset.reduce((acc,bp) => acc + bp.diastolic.value, 0)/bpset.length;
+        const systolicReadings = bpset.filter(r => r.systolic !== null).map(r => r.systolic.value);
+        const avgSys = systolicReadings.reduce((acc,val) => acc + val, 0)/systolicReadings.length;
+        const diastolicReadings = bpset.filter(r => r.diastolic !== null).map(r => r.diastolic.value);
+        const avgDia = diastolicReadings.reduce((acc,val) => acc + val, 0)/diastolicReadings.length;
         return {
             systolic: avgSys,
             diastolic: avgDia

--- a/src/main/resources/static/js/home.js
+++ b/src/main/resources/static/js/home.js
@@ -284,13 +284,28 @@ function toLOESSData(data, type) {
 }
 
 function toLOESSData2(data, type) {
-    // LOESS doesn't work if the data isn't sorted by date first. Make sure it is.
     const sortedData = sortByDateAsc(data);
+
     let map = sortedData.map(function(item) {
         return item[type] != null ? [item.readingDate, item[type].value] : null;
     }).filter(function(item) {
         return item != null;
     });
+
+    // Adjust bandwidth based on number of points in the data
+    let bandwidth = 0.3;
+    let numPts = map.length;
+    // Allow an override of the bandwidth in the URL for testing
+    if (getLOESSBandwidth() !== -1) {
+        bandwidth = getLOESSBandwidth();
+    } else if (numPts <= 8) {
+        bandwidth = 0.6;
+    } else if (numPts <= 15) {
+        bandwidth = 0.5;
+    } else if (numPts <= 25) {
+        bandwidth = 0.4;
+    }
+    console.log("Starting bandwidth: " + bandwidth);
 
     let xval = [], yval = [];
     map.forEach(function(item) {
@@ -298,17 +313,40 @@ function toLOESSData2(data, type) {
         yval.push(item[1]);
     });
 
-    let loess = science.stats.loess().bandwidth(getLOESSBandwidth());
-    let loess_data = loess(xval, yval);
-    let loess_points = loess_data.map(function(yval, index) {
-        return [xval[index], yval];
-    });
+    let loess;
+    // Try incrementally increasing bandwidth if an error is thrown
+    while (bandwidth <= 1.0) {
+        loess = science.stats.loess().bandwidth(bandwidth);
+        try {
+            let loess_data = loess(xval, yval);
+            let loess_points = loess_data.map(function(yval, index) {
+                return [xval[index], yval];
+            });
 
-    return loess_points;
+            console.log("Final bandwidth used: " + bandwidth);
+            // If all values are NaN, fall back on a direct plot
+            if (loess_points.every(pt => isNaN(pt[1]))) {
+                console.log("All LOESS points are NaN. Fall back on direct plot.")
+                return map;
+            }
+            // Filter out NaN values
+            const filtered = loess_points.filter(pt => !isNaN(pt[1]));
+            if (filtered.length < loess_points.length) {
+                console.log("Some points failed regression. Returning a subset.");
+            }
+            return filtered;
+        } catch (error) {
+            bandwidth = bandwidth + 0.1;
+        }
+    }
+
+    // Fall back on a direct plot
+    return map;
+
 }
 
 function getLOESSBandwidth() {
-    return $('#LOESSBandwidth').html();
+    return Number($('#LOESSBandwidth').html());
 }
 
 function getDateRange(data) {


### PR DESCRIPTION
- Add an isNaN check to filter out bad calculated values
- If all points are NaN, fall back on direct plot
- If the regression throws an error, increase the bandwidth by 0.1 and try again until bandwidth is >= 1. Fall back on direct plot if still failing.
- Set the starting bandwidth based on the number of readings:
- <= 8 points - 0.6
- <= 15 points - 0.5
- <= 25 points - 0.4
- else - 0.3
- You can still set the starting bandwidth in the URL parameter for testing purposes and the Javascript console is displaying some debugging statements for now. These will be removed later.