### PR TITLE
Issue #37: Gracefully handle Goal dates from EHR

### DIFF
--- a/src/main/java/edu/ohsu/cmp/coach/fhir/transform/BaseVendorTransformer.java
+++ b/src/main/java/edu/ohsu/cmp/coach/fhir/transform/BaseVendorTransformer.java
@@ -590,6 +590,8 @@ public abstract class BaseVendorTransformer implements VendorTransformer {
                 .setSystem("http://terminology.hl7.org/CodeSystem/goal-achievement");
         g.getCategoryFirstRep().addCoding().setCode(model.getReferenceCode()).setSystem(model.getReferenceSystem());
         g.getDescription().setText(model.getGoalText());
+        DateType x = new DateType(model.getStartDate());
+        g.setStart(x);
         g.setStatusDate(model.getStatusDate());
         g.getTarget().add(new Goal.GoalTargetComponent()
                 .setDue(new DateType().setValue(model.getTargetDate())));

--- a/src/main/java/edu/ohsu/cmp/coach/model/GoalModel.java
+++ b/src/main/java/edu/ohsu/cmp/coach/model/GoalModel.java
@@ -77,9 +77,13 @@ public class GoalModel implements Comparable<GoalModel> {
         }
 
         this.targetDate = null; // EHR-based
-        this.createdDate = g.hasStartDateType() ?
-                g.getStartDateType().getValue() :
-                null;
+        // Fall back on status date if start date doesn't exist. If neither exist, return null
+        this.createdDate = null;
+        if (g.hasStartDateType()) {
+            this.createdDate = g.getStartDateType().getValue();
+        } else if (g.getStatusDate() != null) {
+            this.createdDate = g.getStatusDate();
+        }
 
         history = new TreeSet<>();
     }
@@ -153,7 +157,7 @@ public class GoalModel implements Comparable<GoalModel> {
             Date d1 = getCreatedDate();
             Date d2 = o.getCreatedDate();
             if      (d1 == null && d2 == null)  return 0;
-            else if (d1 != null && d2 != null)  return d1.compareTo(d2);
+            else if (d1 != null && d2 != null)  return d2.compareTo(d1);
             else if (d1 != null)                return -1;
             else                                return 1;
         }
@@ -195,6 +199,10 @@ public class GoalModel implements Comparable<GoalModel> {
         return status != null ?
                 status.getLabel() :
                 null;
+    }
+
+    public Date getStartDate() {
+        return getCreatedDate();
     }
 
     public Date getStatusDate() {

--- a/src/main/java/edu/ohsu/cmp/coach/service/GoalService.java
+++ b/src/main/java/edu/ohsu/cmp/coach/service/GoalService.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class GoalService extends AbstractService {
@@ -127,18 +128,18 @@ public class GoalService extends AbstractService {
     private GoalModel getCurrentEHRBPGoal(String sessionId) {
         GoalModel currentEHRBPGoal = null;
 
-        List<GoalModel> goals = workspaceService.get(sessionId).getGoals();
+        // Remove goals without a createdDate since they can't accurately be compared to others
+        List<GoalModel> goals = workspaceService.get(sessionId).getGoals().
+            stream().filter(g -> g.getCreatedDate() != null).collect(Collectors.toList());
         for (GoalModel goal : goals) {
             if (goal.isEHRGoal() && goal.isBPGoal()) {
                 if (currentEHRBPGoal == null) {
                     currentEHRBPGoal = goal;
-
                 } else if (goal.compareTo(currentEHRBPGoal) < 0) {
                     currentEHRBPGoal = goal;
                 }
             }
         }
-
         return currentEHRBPGoal;
     }
 


### PR DESCRIPTION
- When creating a GoalModel from the EHR BP Goal, try startDate and statusDate before setting createdDate to null
- When determining the latest EHR BP Goal, remove goals without dates from consideration
- For local BP goals, send the startDate in the prefetch, which is equivalent to the day the Goal was first created.