### PR TITLE
#67, #142: Tooltips and responsive display.

### DIFF
--- a/src/main/resources/static/css/coach.css
+++ b/src/main/resources/static/css/coach.css
@@ -130,3 +130,41 @@ body {
 .thick {
     font-weight: bold;
 }
+
+.tip {
+    position: relative;
+    display: inline-block;
+}
+  
+.tip .tiptext {
+    visibility: hidden;
+    width: 300px;
+    background-color: #555;
+    color: #fff;
+    text-align: center;
+    border-radius: 6px;
+    padding: 5px 0;
+    position: absolute;
+    z-index: 1;
+    bottom: 100%;
+    left: 50%;
+    margin-left: -60px;
+    opacity: 0;
+    transition: opacity 0.3s;
+}
+  
+.tip .tiptext::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: #555 transparent transparent transparent;
+}
+  
+.tip:hover .tiptext {
+    visibility: visible;
+    opacity: 1;
+}

--- a/src/main/resources/static/js/home.js
+++ b/src/main/resources/static/js/home.js
@@ -183,6 +183,20 @@ function within14Days(bp) {
     return Math.floor((today - bp.readingDate) / (1000*60*60*24)) <= 14;
 }
 
+// Generic function to remove classes col-md-? and col-lg-? so the actual numbers can change if need be.
+function removeBootstrapCols(selection) {
+    selection.removeClass(function(n, c) {
+        const match = c.match(/(col-md-(\d)+)/);
+        if (c.includes("col-md")) return match[1];
+        else return "";
+    });
+    selection.removeClass(function(n, c) {
+        const match = c.match(/(col-lg-(\d)+)/);
+        if (c.includes("col-lg")) return match[1];
+        else return "";
+    });
+}
+
 function populateSummaryDiv() {
     let mostRecentBP = {};
     let crisisBP = false;
@@ -224,9 +238,9 @@ function populateSummaryDiv() {
     let diastolic = $('#diastolic');
 
     if (twoCrisisBPs || crisisBP || twoLowCrisisBPs || lowCrisisBP) {
-        bpIcon.html("<img src='/images/critical-icon.png' class='bp-icon' alt='Critical' />");
+        bpIcon.html("<img src='/images/critical-icon.png' class='bp-icon' alt='Critical' /><span class='tiptext'>Your most recent BP is very high. Check the Resources tab to learn more about what to do.</span>");
         bpIcon.show();
-        bpIndicatorContainer.removeClass("col-md-3");
+        removeBootstrapCols(bpIndicatorContainer);
         chartContainer.hide();
         bpPlaceholder.hide();
         bpContainer.show();
@@ -256,7 +270,7 @@ function populateSummaryDiv() {
         bpPlaceholder.append("<div class='mt-4'>Enter more blood pressures to see average</div>");
 
     } else if (isBasic()) {
-        bpIndicatorContainer.removeClass("col-md-3");
+        removeBootstrapCols(bpIndicatorContainer);
         chartContainer.hide();
         bpIcon.hide();
         bpNote.hide();
@@ -272,10 +286,10 @@ function populateSummaryDiv() {
 
     } else if (isEnhanced()) {
         if (aboveGoal) {
-            bpIcon.html("<img src='/images/stoplight-yellow.png' class='bp-icon' alt='Above Goal' />");
+            bpIcon.html("<img src='/images/stoplight-yellow.png' class='bp-icon' alt='Above Goal' /><span class='tiptext'>Your average BP is above goal. Average is calculated based on a maximum of 12 recent readings. Check the Resources tab to learn more about what to do.</span>");
             bpNote.html('Your BP is above your goal!');
         } else {
-            bpIcon.html("<img src='/images/stoplight-green.png' class='bp-icon' alt='At or Below Goal' />");
+            bpIcon.html("<img src='/images/stoplight-green.png' class='bp-icon' alt='At or Below Goal' /><span class='tiptext'>Your average BP is at goal. Average is calculated based on a maximum of 12 recent readings. Check the Resources tab to learn more about what to do.</span>");
             bpNote.html('You reached your goal!');
         }
 

--- a/src/main/resources/templates/home.mustache
+++ b/src/main/resources/templates/home.mustache
@@ -18,7 +18,7 @@
         </h4>
         <div class="container">
             <div class="row">
-                <div id="bpIndicatorContainer" class="col-12 col-md-3 align-self-center">
+                <div id="bpIndicatorContainer" class="col-12 col-md-4 col-lg-3 align-self-center">
                     <div class="text-center" style="font-weight: bold;">Your blood pressure:</div>
                     <table class="table table-borderless mt-4 mx-auto w-auto">
                         <tr>
@@ -29,7 +29,8 @@
                                     <table style="text-align:center">
                                         <tr>
                                             <td>
-                                                <div id="bpIcon"></div>
+                                                <div id="bpIcon" class="tip">
+                                                </div>
                                             </td>
                                             <td>
                                                 <table>
@@ -74,7 +75,7 @@
                         </tr>
                     </table>
                 </div>
-                <div id="chartContainer" class="col-12 col-md-9">
+                <div id="chartContainer" class="col-12 col-md-8 col-lg-9">
                     <div class="container">
                         <div class="row">
                             <div class="col">


### PR DESCRIPTION
#67: Add tooltips to stoplight graphics
#142: Fix home page overlapping elements on iPad Mini

<img width="1345" alt="Screen Shot 2023-12-19 at 2 53 36 PM" src="https://github.com/OHSUCMP/coach/assets/2576491/d662207f-d08f-4acb-86d9-841552e4301e">

<img width="1345" alt="Screen Shot 2023-12-19 at 2 56 51 PM" src="https://github.com/OHSUCMP/coach/assets/2576491/ac6161dd-fd9c-4b24-bda5-517a877f3989">

<img width="618" alt="Screen Shot 2023-12-19 at 3 03 03 PM" src="https://github.com/OHSUCMP/coach/assets/2576491/d4c1470c-2824-4f4e-9c78-af86bc552f2f">
