### PR TITLE
#189: Remove reference to card.source which is always empty.

### DIFF
--- a/src/main/resources/static/js/recommendations.js
+++ b/src/main/resources/static/js/recommendations.js
@@ -67,13 +67,6 @@ function renderCards(cards) {
                 html += "<span class='rationale'>" + card.rationale + "</span>";
             }
 
-            if (card.source.label !== null && card.source.url !== null) {
-                html += "<span class='source'>";
-                html += "<a href='" + card.source.url + "' target='_blank' rel='noopener noreferrer'>" +
-                    card.source.label + "</a>";
-                html += "</span>";
-            }
-
             if (card.links !== null) {
                 html += "<div class='links'>";
                 card.links.forEach(function(link) {


### PR DESCRIPTION
card.source is never populated and can be empty or null depending on the version of CQF Ruler. This fixes an issue with VUMC running CQF Ruler 0.13.0.